### PR TITLE
explicitly java target in parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,4 +14,18 @@
         <module>Manager</module>
         <module>ServerHttp</module>
     </modules>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>


### PR DESCRIPTION
Set explicitly java target and source version so IntelliJ doesn't bother with selecting version by default.
This change makes everything works seamlessly after importing module 

Took 5 minutes