### PR TITLE
Module Class Refactor

### DIFF
--- a/Manager/src/main/java/io/raspberrywallet/manager/Configuration.java
+++ b/Manager/src/main/java/io/raspberrywallet/manager/Configuration.java
@@ -96,7 +96,7 @@ final public class Configuration {
      * @param yamlFile configuration file encoded in YAML structure
      * @return YAML config parsed into Configuration object
      */
-    public static Configuration fromYamlFile(File yamlFile) {
+    static Configuration fromYamlFile(File yamlFile) {
         ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
         Configuration config;
         try {

--- a/Manager/src/main/java/io/raspberrywallet/manager/Main.java
+++ b/Manager/src/main/java/io/raspberrywallet/manager/Main.java
@@ -30,7 +30,6 @@ public class Main {
         Bitcoin bitcoin = new Bitcoin(configuration, new WalletCrypter());
 
         List<Module> modules = ModuleClassLoader.getModules(configuration);
-        modules.forEach(Module::register);
 
         TemperatureMonitor temperatureMonitor = new TemperatureMonitor();
 

--- a/Manager/src/main/java/io/raspberrywallet/manager/Manager.java
+++ b/Manager/src/main/java/io/raspberrywallet/manager/Manager.java
@@ -135,7 +135,7 @@ public class Manager implements io.raspberrywallet.contract.Manager {
                 Module module = modulesToDecrypt.get(i);
                 module.setInputs(selectedModulesWithInputs.get(module.getId()));
                 KeyPartEntity keyPartEntity = new KeyPartEntity();
-                keyPartEntity.setPayload(module.validateAndEncrypt(keys[i].toByteArray()));
+                keyPartEntity.setPayload(module.encrypt(keys[i].toByteArray()));
                 keyPartEntity.setModule(module.getId());
                 keyPartEntities.add(keyPartEntity);
             }
@@ -225,7 +225,7 @@ public class Manager implements io.raspberrywallet.contract.Manager {
                             return null;
 
                         KeyPartEntity dbEntity = keyPartEntity.get();
-                        return module.validateAndDecrypt(dbEntity.getPayload());
+                        return module.decrypt(dbEntity.getPayload());
                     } catch (DecryptionException | RequiredInputNotFound e) {
                         e.printStackTrace();
                         return null;

--- a/Manager/src/main/java/io/raspberrywallet/manager/Manager.java
+++ b/Manager/src/main/java/io/raspberrywallet/manager/Manager.java
@@ -135,7 +135,7 @@ public class Manager implements io.raspberrywallet.contract.Manager {
                 Module module = modulesToDecrypt.get(i);
                 module.setInputs(selectedModulesWithInputs.get(module.getId()));
                 KeyPartEntity keyPartEntity = new KeyPartEntity();
-                keyPartEntity.setPayload(module.encrypt(keys[i].toByteArray()));
+                keyPartEntity.setPayload(module.encryptKeyPart(keys[i].toByteArray()));
                 keyPartEntity.setModule(module.getId());
                 keyPartEntities.add(keyPartEntity);
             }
@@ -143,7 +143,7 @@ public class Manager implements io.raspberrywallet.contract.Manager {
 
             bitcoin.setupWalletFromMnemonic(mnemonicCode, getPrivateKeyHash());
 
-        } catch (ShamirException | EncryptionException e) {
+        } catch (ShamirException | EncryptionException | InternalModuleException e) {
             e.printStackTrace();
         }
     }
@@ -225,8 +225,8 @@ public class Manager implements io.raspberrywallet.contract.Manager {
                             return null;
 
                         KeyPartEntity dbEntity = keyPartEntity.get();
-                        return module.decrypt(dbEntity.getPayload());
-                    } catch (DecryptionException | RequiredInputNotFound e) {
+                        return module.decryptKeyPart(dbEntity.getPayload());
+                    } catch (InternalModuleException | DecryptionException | RequiredInputNotFound e) {
                         e.printStackTrace();
                         return null;
                     }

--- a/Manager/src/main/java/io/raspberrywallet/manager/Manager.java
+++ b/Manager/src/main/java/io/raspberrywallet/manager/Manager.java
@@ -135,7 +135,7 @@ public class Manager implements io.raspberrywallet.contract.Manager {
                 Module module = modulesToDecrypt.get(i);
                 module.setInputs(selectedModulesWithInputs.get(module.getId()));
                 KeyPartEntity keyPartEntity = new KeyPartEntity();
-                keyPartEntity.setPayload(module.encrypt(keys[i].toByteArray()));
+                keyPartEntity.setPayload(module.validateAndEncrypt(keys[i].toByteArray()));
                 keyPartEntity.setModule(module.getId());
                 keyPartEntities.add(keyPartEntity);
             }
@@ -225,7 +225,7 @@ public class Manager implements io.raspberrywallet.contract.Manager {
                             return null;
 
                         KeyPartEntity dbEntity = keyPartEntity.get();
-                        return module.decrypt(dbEntity.getPayload());
+                        return module.validateAndDecrypt(dbEntity.getPayload());
                     } catch (DecryptionException | RequiredInputNotFound e) {
                         e.printStackTrace();
                         return null;

--- a/Manager/src/main/java/io/raspberrywallet/manager/modules/Module.java
+++ b/Manager/src/main/java/io/raspberrywallet/manager/modules/Module.java
@@ -36,8 +36,8 @@ public abstract class Module<Config extends ModuleConfig> {
      * This constructor enforce that the state and configuration is always present
      *
      * @param initialStatusString - initial module status string
-     * @param configClass - class representation of module specific Config type,
-     *                    required for dynamic Config class initialization, either from file and default value
+     * @param configClass         - class representation of module specific Config type,
+     *                            required for dynamic Config class initialization, either from file and default value
      */
     public Module(@NotNull String initialStatusString, Class<Config> configClass)
             throws IllegalAccessException, InstantiationException {
@@ -64,8 +64,9 @@ public abstract class Module<Config extends ModuleConfig> {
 
     /**
      * Parses config yaml file representation to module specific Config object
+     *
      * @param moduleConfiguration whole `modules` node of yaml file
-     * @param configClass class representation of module specific Config type
+     * @param configClass         class representation of module specific Config type
      * @return module specific config object
      */
     private Config parseConfigurationFrom(Configuration.ModulesConfiguration moduleConfiguration,
@@ -86,6 +87,7 @@ public abstract class Module<Config extends ModuleConfig> {
     /**
      * Used in all sort of identifications like config.yaml, internal module mapping and UI naming.
      * For now, it's just simplified SimpleClassName
+     *
      * @return module identifier.
      */
     public String getId() {
@@ -99,24 +101,38 @@ public abstract class Module<Config extends ModuleConfig> {
 
     public abstract String getDescription();
 
+    protected abstract void validateInputs() throws RequiredInputNotFound;
+
     /**
-     * Check if needed interaction (User-Module) has been completed
-     *
-     * @return true, if we are ready to decrypt
+     * @param keyPart - decrypted key part
+     * @return encrypted payload
      */
-    public abstract boolean check();
+    public byte[] validateAndEncrypt(byte[] keyPart) throws RequiredInputNotFound, EncryptionException {
+        validateInputs();
+        return encrypt(keyPart);
+    }
 
     /**
      * @param keyPart - unencrypted key part
      * @return encrypted payload
      */
-    public abstract byte[] encrypt(byte[] keyPart) throws RequiredInputNotFound, EncryptionException;
+    protected abstract byte[] encrypt(byte[] keyPart) throws EncryptionException, RequiredInputNotFound;
+
+
+    /**
+     * @param keyPart - encrypted key part
+     * @return decrypted payload
+     */
+    public byte[] validateAndDecrypt(byte[] keyPart) throws RequiredInputNotFound, DecryptionException {
+        validateInputs();
+        return decrypt(keyPart);
+    }
 
     /**
      * @param payload - encrypted payload
      * @return decrypted key part
      */
-    public abstract byte[] decrypt(byte[] payload) throws DecryptionException, RequiredInputNotFound;
+    protected abstract byte[] decrypt(byte[] payload) throws DecryptionException;
 
     /**
      * this function should prepare module before consecutive use.

--- a/Manager/src/main/java/io/raspberrywallet/manager/modules/Module.java
+++ b/Manager/src/main/java/io/raspberrywallet/manager/modules/Module.java
@@ -3,6 +3,7 @@ package io.raspberrywallet.manager.modules;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.stasbar.Logger;
+import io.raspberrywallet.contract.ModuleInitializationException;
 import io.raspberrywallet.contract.RequiredInputNotFound;
 import io.raspberrywallet.manager.Configuration;
 import io.raspberrywallet.manager.cryptography.crypto.exceptions.DecryptionException;
@@ -57,11 +58,12 @@ public abstract class Module<Config extends ModuleConfig> {
 
         statusString = initialStatusString;
         Config newConfiguration = parseConfigurationFrom(modulesConfiguration, configClass);
-        if (newConfiguration == null) newConfiguration = configClass.newInstance();
+        if (newConfiguration == null)
+            newConfiguration = configClass.newInstance();
 
         configuration = newConfiguration;
     }
-
+    
     /**
      * Parses config yaml file representation to module specific Config object
      *
@@ -102,43 +104,18 @@ public abstract class Module<Config extends ModuleConfig> {
     public abstract String getDescription();
 
     protected abstract void validateInputs() throws RequiredInputNotFound;
-
-    /**
-     * @param keyPart - decrypted key part
-     * @return encrypted payload
-     */
-    public byte[] validateAndEncrypt(byte[] keyPart) throws RequiredInputNotFound, EncryptionException {
-        validateInputs();
-        return encrypt(keyPart);
-    }
-
+    
     /**
      * @param keyPart - unencrypted key part
      * @return encrypted payload
      */
-    protected abstract byte[] encrypt(byte[] keyPart) throws EncryptionException, RequiredInputNotFound;
-
-
-    /**
-     * @param keyPart - encrypted key part
-     * @return decrypted payload
-     */
-    public byte[] validateAndDecrypt(byte[] keyPart) throws RequiredInputNotFound, DecryptionException {
-        validateInputs();
-        return decrypt(keyPart);
-    }
+    public abstract byte[] encrypt(byte[] keyPart) throws EncryptionException, RequiredInputNotFound;
 
     /**
      * @param payload - encrypted payload
      * @return decrypted key part
      */
-    protected abstract byte[] decrypt(byte[] payload) throws DecryptionException;
-
-    /**
-     * this function should prepare module before consecutive use.
-     * Manager should call this.
-     */
-    public abstract void register();
+    public abstract byte[] decrypt(byte[] payload) throws DecryptionException, RequiredInputNotFound;
 
     /**
      * this function should return HTML UI form or null if not required

--- a/Manager/src/main/java/io/raspberrywallet/manager/modules/authorizationserver/AuthorizationServerModule.java
+++ b/Manager/src/main/java/io/raspberrywallet/manager/modules/authorizationserver/AuthorizationServerModule.java
@@ -20,7 +20,7 @@ import java.util.Random;
 import java.util.UUID;
 
 public class AuthorizationServerModule extends Module<AuthorizationServerConfig> {
-    private static String PASSWORD = "password";
+    public static String PASSWORD = "password";
     private final static int PASSWORD_SIZE_IN_BYTES = 256;
 
     private final WalletUUIDReader walletUUIDReader = WalletUUIDReader.getInstance();
@@ -62,7 +62,6 @@ public class AuthorizationServerModule extends Module<AuthorizationServerConfig>
     }
 
 
-    @Override
     public boolean check() {
         if (hasInput(PASSWORD)) {
             try {

--- a/Manager/src/main/java/io/raspberrywallet/manager/modules/authorizationserver/AuthorizationServerModule.java
+++ b/Manager/src/main/java/io/raspberrywallet/manager/modules/authorizationserver/AuthorizationServerModule.java
@@ -1,6 +1,6 @@
 package io.raspberrywallet.manager.modules.authorizationserver;
 
-import io.raspberrywallet.contract.ModuleInitializationException;
+import io.raspberrywallet.contract.InternalModuleException;
 import io.raspberrywallet.contract.RequiredInputNotFound;
 import io.raspberrywallet.manager.Configuration;
 import io.raspberrywallet.manager.common.generators.RandomStringGenerator;
@@ -15,9 +15,7 @@ import io.raspberrywallet.manager.modules.Module;
 import org.apache.commons.lang.SerializationUtils;
 import org.jetbrains.annotations.Nullable;
 
-import java.security.SecureRandom;
 import java.util.Base64;
-import java.util.Random;
 import java.util.UUID;
 
 public class AuthorizationServerModule extends Module<AuthorizationServerConfig> {
@@ -32,18 +30,14 @@ public class AuthorizationServerModule extends Module<AuthorizationServerConfig>
 
     private final AuthorizationServerAPI serverAPI = new AuthorizationServerAPI(configuration);
 
-    private Random random = new SecureRandom();
-
     public AuthorizationServerModule() throws InstantiationException, IllegalAccessException {
         super("Please enter username and password for external server.", AuthorizationServerConfig.class);
-        tryGetInputsAndInitialize();
     }
 
     public AuthorizationServerModule(Configuration.ModulesConfiguration modulesConfiguration) throws InstantiationException, IllegalAccessException {
         super("Please enter username and password for external server.", modulesConfiguration, AuthorizationServerConfig.class);
-        tryGetInputsAndInitialize();
     }
-    
+
     @Override
     protected void validateInputs() throws RequiredInputNotFound {
         if (hasInput(PASSWORD)) {
@@ -51,46 +45,32 @@ public class AuthorizationServerModule extends Module<AuthorizationServerConfig>
             if (password != null)
                 serverCredentials = new Credentials(walletUUID.toString(),
                         Base64.getUrlEncoder().encodeToString(password.getBytes()));
-        }
-        else if (serverCredentials == null)
-            throw new RequiredInputNotFound(AuthorizationServerModule.class.getName(), "password");
+        } else if (serverCredentials == null)
+            throw new RequiredInputNotFound(AuthorizationServerModule.class.getName(), PASSWORD);
     }
-    
-    private void initialize() throws ModuleInitializationException {
+
+    private void callServer() throws InternalModuleException {
         try {
-            validateInputs();
-            
             if (!serverAPI.isRegistered(serverCredentials))
                 serverAPI.register(serverCredentials);
-            
+
             if (!serverAPI.isLoggedIn())
                 serverAPI.login(serverCredentials);
-            
+
             if (!serverAPI.secretIsSet(serverCredentials)) {
                 String randomSecret = RandomStringGenerator.get(PASSWORD_SIZE_IN_BYTES);
                 serverAPI.overwriteSecret(serverCredentials, randomSecret);
             }
-        } catch (RequestException | RequiredInputNotFound e) {
-            throw new ModuleInitializationException(
-                    "Failed to initialize module " + AuthorizationServerConfig.class.getName() + ":" + e.getMessage());
+        } catch (RequestException e) {
+            throw new InternalModuleException(
+                    "Request exception in module " + AuthorizationServerConfig.class.getName() + ":" + e.getMessage());
         }
     }
-    
-    private void tryGetInputsAndInitialize() {
-        // if it's possible, try to get inputs and initialize module
-        try {
-            validateInputs();
-            initialize();
-        } catch (RequiredInputNotFound | ModuleInitializationException ignored) {
-        
-        }
-    }
-    
-    @Override
-    public byte[] encrypt(byte[] payload) throws EncryptionException, RequiredInputNotFound {
-        try {
-            initialize();
 
+    @Override
+    protected byte[] encrypt(byte[] payload) throws EncryptionException, InternalModuleException {
+        try {
+            callServer();
             String password = serverAPI.getSecret(serverCredentials);
 
             AESEncryptedObject<ByteWrapper> encryptedSecret =
@@ -100,18 +80,13 @@ public class AuthorizationServerModule extends Module<AuthorizationServerConfig>
 
         } catch (RequestException e) {
             throw new EncryptionException(e.getMessage());
-        } catch (ModuleInitializationException e) {
-            throw new RequiredInputNotFound(AuthorizationServerModule.class.getName()
-                            + " has no required inputs or failed on initialization phase. Message: "
-                            + e.getMessage());
         }
     }
-    
+
     @Override
-    public byte[] decrypt(byte[] keyPart) throws DecryptionException, RequiredInputNotFound {
+    protected byte[] decrypt(byte[] keyPart) throws DecryptionException, InternalModuleException {
         try {
-            initialize();
-    
+            callServer();
             String password = serverAPI.getSecret(serverCredentials);
 
             AESEncryptedObject<ByteWrapper> deserializedKeyPart =
@@ -120,23 +95,19 @@ public class AuthorizationServerModule extends Module<AuthorizationServerConfig>
             return CryptoObject.decrypt(deserializedKeyPart, password).getData();
 
         } catch (RequestException e) {
-            throw new DecryptionException(e.getMessage());
-        } catch (ModuleInitializationException e) {
-            throw new RequiredInputNotFound(AuthorizationServerModule.class.getName()
-                    + " has no required inputs or failed on initialization phase. Message: "
-                    + e.getMessage());
+            throw new InternalModuleException(e.getMessage());
         }
     }
-    
+
     @Override
     public String getDescription() {
         return "This module is authenticating user with external authorization server.";
     }
-    
+
     @Nullable
     @Override
     public String getHtmlUi() {
         return "<input type=\"text\" name=\"password\">";
     }
-    
+
 }

--- a/Manager/src/main/java/io/raspberrywallet/manager/modules/authorizationserver/AuthorizationServerModule.java
+++ b/Manager/src/main/java/io/raspberrywallet/manager/modules/authorizationserver/AuthorizationServerModule.java
@@ -1,5 +1,6 @@
 package io.raspberrywallet.manager.modules.authorizationserver;
 
+import io.raspberrywallet.contract.RequiredInputNotFound;
 import io.raspberrywallet.manager.Configuration;
 import io.raspberrywallet.manager.common.generators.RandomStringGenerator;
 import io.raspberrywallet.manager.common.readers.WalletUUIDReader;
@@ -13,14 +14,13 @@ import io.raspberrywallet.manager.modules.Module;
 import org.apache.commons.lang.SerializationUtils;
 import org.jetbrains.annotations.Nullable;
 
-import java.nio.charset.Charset;
 import java.security.SecureRandom;
 import java.util.Base64;
 import java.util.Random;
 import java.util.UUID;
 
 public class AuthorizationServerModule extends Module<AuthorizationServerConfig> {
-
+    private static String PASSWORD = "password";
     private final static int PASSWORD_SIZE_IN_BYTES = 256;
 
     private final WalletUUIDReader walletUUIDReader = WalletUUIDReader.getInstance();
@@ -46,11 +46,27 @@ public class AuthorizationServerModule extends Module<AuthorizationServerConfig>
         return "This module is authenticating user with external authorization server.";
     }
 
+
+    /**
+     * There is no need to take actions before next encryption/decryption
+     * operations, so there is no point in implementing this method.
+     */
+    @Override
+    public void register() {
+    }
+
+    @Nullable
+    @Override
+    public String getHtmlUi() {
+        return "<input type=\"text\" name=\"password\">";
+    }
+
+
     @Override
     public boolean check() {
-        if (hasInput("password")) {
+        if (hasInput(PASSWORD)) {
             try {
-                String password = getInput("password");
+                String password = getInput(PASSWORD);
                 serverCredentials = new Credentials(walletUUID.toString(),
                         Base64.getUrlEncoder().encodeToString(password.getBytes()));
                 initialize();
@@ -110,19 +126,9 @@ public class AuthorizationServerModule extends Module<AuthorizationServerConfig>
         }
     }
 
-    /**
-     * There is no need to take actions before next encryption/decryption
-     * operations, so there is no point in implementing this method.
-     */
     @Override
-    public void register() {
-    }
+    protected void validateInputs() throws RequiredInputNotFound {
 
-    @Nullable
-    @Override
-    public String getHtmlUi() {
-        return "<input type=\"text\" name=\"password\">";
     }
-
 
 }

--- a/Manager/src/main/java/io/raspberrywallet/manager/modules/example/ExampleModule.java
+++ b/Manager/src/main/java/io/raspberrywallet/manager/modules/example/ExampleModule.java
@@ -32,7 +32,7 @@ public class ExampleModule extends Module<ExampleConfig> {
      * Before we can decrypt a keypart, we need an encrypted one
      */
     @Override
-    public byte[] encrypt(byte[] data) {
+    protected byte[] encrypt(byte[] data) {
         byte[] r = data.clone();
         for (int i = 0; i < r.length; ++i)
             r[i] = (byte) (r[i] ^ KEY[i % KEY.length]);
@@ -43,7 +43,7 @@ public class ExampleModule extends Module<ExampleConfig> {
      * We are processing (decrypting) the keypart with a KEY.
      */
     @Override
-    public byte[] decrypt(byte[] payload) throws DecryptionException {
+    protected byte[] decrypt(byte[] payload) throws DecryptionException {
         if (payload == null) throw new DecryptionException(DecryptionException.NO_DATA);
 
         byte[] r = payload.clone();

--- a/Manager/src/main/java/io/raspberrywallet/manager/modules/example/ExampleModule.java
+++ b/Manager/src/main/java/io/raspberrywallet/manager/modules/example/ExampleModule.java
@@ -1,6 +1,7 @@
 package io.raspberrywallet.manager.modules.example;
 
 
+import io.raspberrywallet.contract.RequiredInputNotFound;
 import io.raspberrywallet.manager.Configuration;
 import io.raspberrywallet.manager.cryptography.crypto.exceptions.DecryptionException;
 import io.raspberrywallet.manager.modules.Module;
@@ -19,30 +20,13 @@ public class ExampleModule extends Module<ExampleConfig> {
         return "An example waiting and xoring module to show how things work.";
     }
 
+
     public static final byte[] KEY = "EXAMPLEKEY".getBytes();
 
-    /*
-     * First the module is "registered" by manager just after user needs to decrypt keypart.
-     */
-    private long lastTime = 1000;
-
-    @Override
-    public void register() {
-        lastTime = System.currentTimeMillis();
-    }
 
     @Override
     public String getHtmlUi() {
         return null;
-    }
-
-    /*
-     * The manager checks periodically for status. If status is true (i.e. here 5 seconds passed),
-     * process() should be called
-     */
-    @Override
-    public boolean check() {
-        return System.currentTimeMillis() - lastTime > 5000;
     }
 
     /*
@@ -69,5 +53,13 @@ public class ExampleModule extends Module<ExampleConfig> {
             r[i] = (byte) (r[i] ^ KEY[i % KEY.length]);
 
         return r;
+    }
+
+    @Override
+    public void register() {
+    }
+
+    @Override
+    protected void validateInputs() throws RequiredInputNotFound {
     }
 }

--- a/Manager/src/main/java/io/raspberrywallet/manager/modules/example/ExampleModule.java
+++ b/Manager/src/main/java/io/raspberrywallet/manager/modules/example/ExampleModule.java
@@ -1,7 +1,6 @@
 package io.raspberrywallet.manager.modules.example;
 
 
-import io.raspberrywallet.contract.RequiredInputNotFound;
 import io.raspberrywallet.manager.Configuration;
 import io.raspberrywallet.manager.cryptography.crypto.exceptions.DecryptionException;
 import io.raspberrywallet.manager.modules.Module;
@@ -54,12 +53,8 @@ public class ExampleModule extends Module<ExampleConfig> {
 
         return r;
     }
-
+    
     @Override
-    public void register() {
-    }
-
-    @Override
-    protected void validateInputs() throws RequiredInputNotFound {
+    protected void validateInputs() {
     }
 }

--- a/Manager/src/main/java/io/raspberrywallet/manager/modules/pin/PinModule.java
+++ b/Manager/src/main/java/io/raspberrywallet/manager/modules/pin/PinModule.java
@@ -11,7 +11,7 @@ import io.raspberrywallet.manager.modules.Module;
 import org.apache.commons.lang.SerializationUtils;
 
 public class PinModule extends Module<PinConfig> {
-    
+
     public PinModule() throws InstantiationException, IllegalAccessException {
         super("Enter PIN", PinConfig.class);
     }
@@ -25,11 +25,6 @@ public class PinModule extends Module<PinConfig> {
         return "Module that require enter a digit code to unlock.";
     }
 
-    @Override
-    public boolean check() {
-        return hasInput("pin");
-    }
-
 
     @Override
     public void register() {
@@ -41,32 +36,29 @@ public class PinModule extends Module<PinConfig> {
     }
 
     @Override
-    public byte[] encrypt(byte[] payload) throws RequiredInputNotFound, EncryptionException {
+    public byte[] encrypt(byte[] payload) throws EncryptionException {
         AESEncryptedObject<ByteWrapper> encryptedObject =
-                CryptoObject.encrypt(new ByteWrapper(payload), getPin());
-        
+                CryptoObject.encrypt(new ByteWrapper(payload), getInput(PIN));
+
         return SerializationUtils.serialize(encryptedObject);
     }
 
     @Override
-    public byte[] decrypt(byte[] payload) throws RequiredInputNotFound, DecryptionException {
+    public byte[] decrypt(byte[] payload) throws DecryptionException {
         AESEncryptedObject<ByteWrapper> encryptedObject =
                 (AESEncryptedObject<ByteWrapper>) SerializationUtils.deserialize(payload);
 
-        return CryptoObject.decrypt(encryptedObject, getPin()).getData();
-    }
-    
-    private String getPin() throws RequiredInputNotFound {
-        String pin = getInput("pin");
-        
-        //validation of user's input
-        if (pin == null || pin.length() < configuration.minLength || pin.length() > configuration.maxLength)
-            throw new RequiredInputNotFound(getId(), "pin");
-        
-        return pin;
+        return CryptoObject.decrypt(encryptedObject, getInput(PIN)).getData();
     }
 
-    public static class Inputs {
-        public static String PIN = "pin";
+    @Override
+    protected void validateInputs() throws RequiredInputNotFound {
+        String pin = getInput(PIN);
+        if (pin == null || pin.length() < configuration.minLength || pin.length() > configuration.maxLength)
+            throw new RequiredInputNotFound(getId(), PIN);
     }
+
+
+    private static String PIN = "pin";
+
 }

--- a/Manager/src/main/java/io/raspberrywallet/manager/modules/pin/PinModule.java
+++ b/Manager/src/main/java/io/raspberrywallet/manager/modules/pin/PinModule.java
@@ -11,7 +11,7 @@ import io.raspberrywallet.manager.modules.Module;
 import org.apache.commons.lang.SerializationUtils;
 
 public class PinModule extends Module<PinConfig> {
-    private static String PIN = "pin";
+    public static String PIN = "pin";
 
     public PinModule() throws InstantiationException, IllegalAccessException {
         super("Enter PIN", PinConfig.class);

--- a/Manager/src/main/java/io/raspberrywallet/manager/modules/pin/PinModule.java
+++ b/Manager/src/main/java/io/raspberrywallet/manager/modules/pin/PinModule.java
@@ -11,6 +11,7 @@ import io.raspberrywallet.manager.modules.Module;
 import org.apache.commons.lang.SerializationUtils;
 
 public class PinModule extends Module<PinConfig> {
+    private static String PIN = "pin";
 
     public PinModule() throws InstantiationException, IllegalAccessException {
         super("Enter PIN", PinConfig.class);
@@ -58,7 +59,5 @@ public class PinModule extends Module<PinConfig> {
             throw new RequiredInputNotFound(getId(), PIN);
     }
 
-
-    private static String PIN = "pin";
 
 }

--- a/Manager/src/main/java/io/raspberrywallet/manager/modules/pin/PinModule.java
+++ b/Manager/src/main/java/io/raspberrywallet/manager/modules/pin/PinModule.java
@@ -33,7 +33,7 @@ public class PinModule extends Module<PinConfig> {
     }
 
     @Override
-    public byte[] encrypt(byte[] payload) throws EncryptionException {
+    protected byte[] encrypt(byte[] payload) throws EncryptionException {
         AESEncryptedObject<ByteWrapper> encryptedObject =
                 CryptoObject.encrypt(new ByteWrapper(payload), getInput(PIN));
 
@@ -41,7 +41,7 @@ public class PinModule extends Module<PinConfig> {
     }
 
     @Override
-    public byte[] decrypt(byte[] payload) throws DecryptionException {
+    protected byte[] decrypt(byte[] payload) throws DecryptionException {
         AESEncryptedObject<ByteWrapper> encryptedObject =
                 (AESEncryptedObject<ByteWrapper>) SerializationUtils.deserialize(payload);
 

--- a/Manager/src/main/java/io/raspberrywallet/manager/modules/pin/PinModule.java
+++ b/Manager/src/main/java/io/raspberrywallet/manager/modules/pin/PinModule.java
@@ -1,5 +1,6 @@
 package io.raspberrywallet.manager.modules.pin;
 
+import io.raspberrywallet.contract.ModuleInitializationException;
 import io.raspberrywallet.contract.RequiredInputNotFound;
 import io.raspberrywallet.manager.Configuration;
 import io.raspberrywallet.manager.common.wrappers.ByteWrapper;
@@ -13,22 +14,17 @@ import org.apache.commons.lang.SerializationUtils;
 public class PinModule extends Module<PinConfig> {
     public static String PIN = "pin";
 
-    public PinModule() throws InstantiationException, IllegalAccessException {
+    public PinModule() throws InstantiationException, IllegalAccessException, ModuleInitializationException {
         super("Enter PIN", PinConfig.class);
     }
 
-    public PinModule(Configuration.ModulesConfiguration modulesConfiguration) throws InstantiationException, IllegalAccessException {
+    public PinModule(Configuration.ModulesConfiguration modulesConfiguration) throws InstantiationException, IllegalAccessException, ModuleInitializationException {
         super("Enter PIN", modulesConfiguration, PinConfig.class);
     }
 
     @Override
     public String getDescription() {
         return "Module that require enter a digit code to unlock.";
-    }
-
-
-    @Override
-    public void register() {
     }
 
     @Override
@@ -55,8 +51,12 @@ public class PinModule extends Module<PinConfig> {
     @Override
     protected void validateInputs() throws RequiredInputNotFound {
         String pin = getInput(PIN);
-        if (pin == null || pin.length() < configuration.minLength || pin.length() > configuration.maxLength)
+        if (isPINWeak(pin))
             throw new RequiredInputNotFound(getId(), PIN);
+    }
+    
+    private boolean isPINWeak(String pin) {
+        return pin == null || pin.length() < configuration.minLength || pin.length() > configuration.maxLength;
     }
 
 

--- a/Manager/src/main/java/io/raspberrywallet/manager/modules/pushbutton/PushButtonModule.java
+++ b/Manager/src/main/java/io/raspberrywallet/manager/modules/pushbutton/PushButtonModule.java
@@ -2,6 +2,7 @@ package io.raspberrywallet.manager.modules.pushbutton;
 
 import com.pi4j.io.gpio.*;
 import com.pi4j.io.gpio.event.GpioPinListenerDigital;
+import io.raspberrywallet.contract.RequiredInputNotFound;
 import io.raspberrywallet.manager.Configuration;
 import io.raspberrywallet.manager.modules.Module;
 
@@ -38,10 +39,6 @@ public class PushButtonModule extends Module<PushButtonConfig> {
         return "Module for pushing physical button on the hardware wallet.";
     }
 
-    @Override
-    public boolean check() {
-        return hasInput(PRESSED) && Boolean.parseBoolean(getInput(PRESSED));
-    }
 
     @Override
     public void register() {
@@ -65,7 +62,13 @@ public class PushButtonModule extends Module<PushButtonConfig> {
         return payload;
     }
 
-    public static class Inputs {
-        public static String PRESSED = "pressed";
+    @Override
+    protected void validateInputs() throws RequiredInputNotFound {
+        if (!hasInput(PRESSED) || !Boolean.parseBoolean(getInput(PRESSED)))
+            throw new RequiredInputNotFound(getId(), PRESSED);
+    }
+
+    static class Inputs {
+        static String PRESSED = "pressed";
     }
 }

--- a/Manager/src/main/java/io/raspberrywallet/manager/modules/pushbutton/PushButtonModule.java
+++ b/Manager/src/main/java/io/raspberrywallet/manager/modules/pushbutton/PushButtonModule.java
@@ -6,10 +6,8 @@ import io.raspberrywallet.contract.RequiredInputNotFound;
 import io.raspberrywallet.manager.Configuration;
 import io.raspberrywallet.manager.modules.Module;
 
-import static io.raspberrywallet.manager.modules.pushbutton.PushButtonModule.Inputs.PRESSED;
-
 public class PushButtonModule extends Module<PushButtonConfig> {
-
+    private static String PRESSED = "pressed";
     private final static Pin BUTTON_GPIO_PINS = RaspiPin.GPIO_23;
 
     private final GpioController gpio;
@@ -68,7 +66,4 @@ public class PushButtonModule extends Module<PushButtonConfig> {
             throw new RequiredInputNotFound(getId(), PRESSED);
     }
 
-    static class Inputs {
-        static String PRESSED = "pressed";
-    }
 }

--- a/Manager/src/main/java/io/raspberrywallet/manager/modules/pushbutton/PushButtonModule.java
+++ b/Manager/src/main/java/io/raspberrywallet/manager/modules/pushbutton/PushButtonModule.java
@@ -7,7 +7,7 @@ import io.raspberrywallet.manager.Configuration;
 import io.raspberrywallet.manager.modules.Module;
 
 public class PushButtonModule extends Module<PushButtonConfig> {
-    private static String PRESSED = "pressed";
+    public static String PRESSED = "pressed";
     private final static Pin BUTTON_GPIO_PINS = RaspiPin.GPIO_23;
 
     private final GpioController gpio;

--- a/Manager/src/main/java/io/raspberrywallet/manager/modules/pushbutton/PushButtonModule.java
+++ b/Manager/src/main/java/io/raspberrywallet/manager/modules/pushbutton/PushButtonModule.java
@@ -42,12 +42,12 @@ public class PushButtonModule extends Module<PushButtonConfig> {
     }
     
     @Override
-    public byte[] encrypt(byte[] data) {
+    protected byte[] encrypt(byte[] data) {
         return data;
     }
     
     @Override
-    public byte[] decrypt(byte[] payload) {
+    protected byte[] decrypt(byte[] payload) {
         return payload;
     }
     

--- a/Manager/src/main/java/io/raspberrywallet/manager/modules/pushbutton/PushButtonModule.java
+++ b/Manager/src/main/java/io/raspberrywallet/manager/modules/pushbutton/PushButtonModule.java
@@ -18,52 +18,53 @@ public class PushButtonModule extends Module<PushButtonConfig> {
         super("Press Button", PushButtonConfig.class);
         this.gpio = gpio;
         pushButton = gpio.provisionDigitalInputPin(BUTTON_GPIO_PINS);
+        initialize();
     }
 
     public PushButtonModule() throws InstantiationException, IllegalAccessException {
         super("Press Button", PushButtonConfig.class);
         gpio = GpioFactory.getInstance();
         pushButton = gpio.provisionDigitalInputPin(BUTTON_GPIO_PINS);
+        initialize();
     }
 
     public PushButtonModule(Configuration.ModulesConfiguration modulesConfiguration) throws InstantiationException, IllegalAccessException {
         super("Press Button", modulesConfiguration, PushButtonConfig.class);
         gpio = GpioFactory.getInstance();
         pushButton = gpio.provisionDigitalInputPin(BUTTON_GPIO_PINS);
+        initialize();
     }
-
-    @Override
-    public String getDescription() {
-        return "Module for pushing physical button on the hardware wallet.";
-    }
-
-
-    @Override
-    public void register() {
+    
+    private void initialize() {
         pushButton.addListener((GpioPinListenerDigital) event ->
                 setInput(PRESSED, event.getState().isHigh() + "")
         );
     }
-
-    @Override
-    public String getHtmlUi() {
-        return null;
-    }
-
+    
     @Override
     public byte[] encrypt(byte[] data) {
         return data;
     }
-
+    
     @Override
     public byte[] decrypt(byte[] payload) {
         return payload;
     }
-
+    
     @Override
     protected void validateInputs() throws RequiredInputNotFound {
         if (!hasInput(PRESSED) || !Boolean.parseBoolean(getInput(PRESSED)))
             throw new RequiredInputNotFound(getId(), PRESSED);
+    }
+    
+    @Override
+    public String getDescription() {
+        return "Module for pushing physical button on the hardware wallet.";
+    }
+    
+    @Override
+    public String getHtmlUi() {
+        return null;
     }
 
 }

--- a/Manager/src/test/java/io/raspberrywallet/manager/ConfigurationTest.java
+++ b/Manager/src/test/java/io/raspberrywallet/manager/ConfigurationTest.java
@@ -14,7 +14,6 @@ class ConfigurationTest {
     @Test
     void fromYamlFile() throws IOException {
         String version = "0.5.0";
-        long sessionLength = 3600000;
         String basePrefixDir = "/opt/wallet";
         String configYamlContent = "" +
                 "version: " + version + "\n" +
@@ -23,11 +22,6 @@ class ConfigurationTest {
                 "bitcoin:\n" +
                 "  network: testnet\n" +
                 "  user-agent: RaspberryWallet\n" +
-                "\n" +
-                "\n" +
-                "modules:\n" +
-                "  PinModule:\n" +
-                "    max-retry: 5\n" +
                 "\n" +
                 "  AuthorizationServerModule:\n" +
                 "    host: 89.89.89.89\n" +

--- a/Manager/src/test/java/io/raspberrywallet/manager/ManagerTest.java
+++ b/Manager/src/test/java/io/raspberrywallet/manager/ManagerTest.java
@@ -1,9 +1,6 @@
 package io.raspberrywallet.manager;
 
-import io.raspberrywallet.contract.ModuleInitializationException;
-import io.raspberrywallet.contract.RequiredInputNotFound;
-import io.raspberrywallet.contract.WalletNotInitialized;
-import io.raspberrywallet.contract.WalletStatus;
+import io.raspberrywallet.contract.*;
 import io.raspberrywallet.contract.module.ModuleState;
 import io.raspberrywallet.manager.bitcoin.Bitcoin;
 import io.raspberrywallet.manager.cryptography.crypto.exceptions.EncryptionException;
@@ -122,13 +119,13 @@ class ManagerTest {
     }
 
     @Test
-    void unlockWalletWhenUnlocked() throws WalletNotInitialized, RequiredInputNotFound, EncryptionException {
+    void unlockWalletWhenUnlocked() throws WalletNotInitialized, RequiredInputNotFound, EncryptionException, InternalModuleException {
         when(bitcoin.getWallet()).thenReturn(Wallet.fromSeed(TestNet3Params.get(), seed));
 
         ShamirKey exampleKey = new ShamirKey(BigInteger.ONE, BigInteger.TEN, BigInteger.ONE);
         ShamirKey pinKey = new ShamirKey(BigInteger.TEN, BigInteger.ONE, BigInteger.TEN);
-        final KeyPartEntity exampleKeyPart = new KeyPartEntity(exampleModule.encrypt(exampleKey.toByteArray()), exampleModule.getId());
-        final KeyPartEntity pinKeyPart = new KeyPartEntity(pinModule.encrypt(pinKey.toByteArray()), pinModule.getId());
+        final KeyPartEntity exampleKeyPart = new KeyPartEntity(exampleModule.encryptKeyPart(exampleKey.toByteArray()), exampleModule.getId());
+        final KeyPartEntity pinKeyPart = new KeyPartEntity(pinModule.encryptKeyPart(pinKey.toByteArray()), pinModule.getId());
         when(database.getKeypartForModuleId(exampleModule.getId())).thenReturn(Optional.of(exampleKeyPart));
         when(database.getKeypartForModuleId(pinModule.getId())).thenReturn(Optional.of(pinKeyPart));
 
@@ -141,15 +138,15 @@ class ManagerTest {
     }
 
     @Test
-    void lockWalletWhenUnlocked() throws WalletNotInitialized, EncryptionException {
+    void lockWalletWhenUnlocked() throws WalletNotInitialized, EncryptionException, InternalModuleException, RequiredInputNotFound {
         when(bitcoin.getWallet()).thenReturn(Wallet.fromSeed(TestNet3Params.get(), seed));
 
         pinModule.setInput(PinModule.PIN, "1234");
 
         ShamirKey exampleKey = new ShamirKey(BigInteger.ONE, BigInteger.TEN, BigInteger.ONE);
         ShamirKey pinKey = new ShamirKey(BigInteger.TEN, BigInteger.ONE, BigInteger.TEN);
-        final KeyPartEntity exampleKeyPart = new KeyPartEntity(exampleModule.encrypt(exampleKey.toByteArray()), exampleModule.getId());
-        final KeyPartEntity pinKeyPart = new KeyPartEntity(pinModule.encrypt(pinKey.toByteArray()), pinModule.getId());
+        final KeyPartEntity exampleKeyPart = new KeyPartEntity(exampleModule.encryptKeyPart(exampleKey.toByteArray()), exampleModule.getId());
+        final KeyPartEntity pinKeyPart = new KeyPartEntity(pinModule.encryptKeyPart(pinKey.toByteArray()), pinModule.getId());
         when(database.getKeypartForModuleId(exampleModule.getId())).thenReturn(Optional.of(exampleKeyPart));
         when(database.getKeypartForModuleId(pinModule.getId())).thenReturn(Optional.of(pinKeyPart));
 
@@ -163,7 +160,7 @@ class ManagerTest {
     }
 
     @Test
-    void unlockWalletWhenLocked() throws WalletNotInitialized, RequiredInputNotFound, EncryptionException {
+    void unlockWalletWhenLocked() throws WalletNotInitialized, RequiredInputNotFound, EncryptionException, InternalModuleException {
         lockWalletWhenUnlocked();
 
         Map<String, Map<String, String>> moduleToInputsMap = new HashMap<>();

--- a/Manager/src/test/java/io/raspberrywallet/manager/ManagerTest.java
+++ b/Manager/src/test/java/io/raspberrywallet/manager/ManagerTest.java
@@ -110,7 +110,7 @@ class ManagerTest {
         mnemonicCode.forEach(System.out::println);
 
         Map<String, String> pinInputs = new HashMap<>();
-        pinInputs.put(PinModule.Inputs.PIN, "1234");
+        pinInputs.put(PinModule.PIN, "1234");
 
         Map<String, Map<String, String>> selectedModulesWithInputs = new HashMap<>();
         selectedModulesWithInputs.put(pinModule.getId(), pinInputs);
@@ -133,7 +133,7 @@ class ManagerTest {
 
         Map<String, Map<String, String>> moduleToInputsMap = new HashMap<>();
         HashMap<String, String> pinInputs = new HashMap<>();
-        pinInputs.put(PinModule.Inputs.PIN, "1234");
+        pinInputs.put(PinModule.PIN, "1234");
         moduleToInputsMap.put(pinModule.getId(), pinInputs);
 
         assertThrows(IllegalStateException.class, () -> manager.unlockWallet(moduleToInputsMap));
@@ -143,7 +143,7 @@ class ManagerTest {
     void lockWalletWhenUnlocked() throws WalletNotInitialized, RequiredInputNotFound, EncryptionException {
         when(bitcoin.getWallet()).thenReturn(Wallet.fromSeed(TestNet3Params.get(), seed));
 
-        pinModule.setInput(PinModule.Inputs.PIN, "1234");
+        pinModule.setInput(PinModule.PIN, "1234");
 
         ShamirKey exampleKey = new ShamirKey(BigInteger.ONE, BigInteger.TEN, BigInteger.ONE);
         ShamirKey pinKey = new ShamirKey(BigInteger.TEN, BigInteger.ONE, BigInteger.TEN);
@@ -158,7 +158,7 @@ class ManagerTest {
 
         assertTrue(walletFile.exists());
         assertEquals(manager.getWalletStatus(), WalletStatus.ENCRYPTED);
-        assertFalse(pinModule.hasInput(PinModule.Inputs.PIN));
+        assertFalse(pinModule.hasInput(PinModule.PIN));
     }
 
     @Test
@@ -167,7 +167,7 @@ class ManagerTest {
 
         Map<String, Map<String, String>> moduleToInputsMap = new HashMap<>();
         HashMap<String, String> pinInputs = new HashMap<>();
-        pinInputs.put(PinModule.Inputs.PIN, "1234");
+        pinInputs.put(PinModule.PIN, "1234");
         moduleToInputsMap.put(pinModule.getId(), pinInputs);
 
         manager.unlockWallet(moduleToInputsMap);

--- a/Manager/src/test/java/io/raspberrywallet/manager/ManagerTest.java
+++ b/Manager/src/test/java/io/raspberrywallet/manager/ManagerTest.java
@@ -1,5 +1,6 @@
 package io.raspberrywallet.manager;
 
+import io.raspberrywallet.contract.ModuleInitializationException;
 import io.raspberrywallet.contract.RequiredInputNotFound;
 import io.raspberrywallet.contract.WalletNotInitialized;
 import io.raspberrywallet.contract.WalletStatus;
@@ -53,7 +54,7 @@ class ManagerTest {
     private static File walletFile = new File("test_wallet.wallet");
 
     @BeforeEach
-    void setup() throws IllegalAccessException, InstantiationException {
+    void setup() throws IllegalAccessException, InstantiationException, ModuleInitializationException {
         bitcoin = mock(Bitcoin.class);
         temperatureMonitor = mock(TemperatureMonitor.class);
         database = mock(Database.class);
@@ -140,7 +141,7 @@ class ManagerTest {
     }
 
     @Test
-    void lockWalletWhenUnlocked() throws WalletNotInitialized, RequiredInputNotFound, EncryptionException {
+    void lockWalletWhenUnlocked() throws WalletNotInitialized, EncryptionException {
         when(bitcoin.getWallet()).thenReturn(Wallet.fromSeed(TestNet3Params.get(), seed));
 
         pinModule.setInput(PinModule.PIN, "1234");

--- a/Manager/src/test/java/io/raspberrywallet/manager/bitcoin/BitcoinTest.java
+++ b/Manager/src/test/java/io/raspberrywallet/manager/bitcoin/BitcoinTest.java
@@ -5,6 +5,7 @@ import io.raspberrywallet.manager.Configuration;
 import org.bitcoinj.core.Sha256Hash;
 import org.bitcoinj.store.BlockStoreException;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -17,6 +18,7 @@ import static io.raspberrywallet.manager.Utils.println;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+@Disabled("Long running and resource consuming tests")
 public class BitcoinTest {
     static private Bitcoin bitcoin;
     static private List<String> mnemonicCode;
@@ -28,7 +30,7 @@ public class BitcoinTest {
                 "captain", "dutch", "matter", "dinner", "loan", "orange");
         println("Using mnemonic:" + mnemonicCode.stream().reduce("", (acc, word) -> acc + " " + word));
         // receive address mhTMbU8NqwVobEjT6Yqq3hSu9rmPABE1RU
-        // balance 0.14001595
+        // balance 0.15001595
         privateKeyHash = new String(Sha256Hash.hash("rasperrywallet is the best bitcoin wallet ever".getBytes()));
 
         File tempBaseDir = Paths.get("/", "tmp", "wallet").toFile();

--- a/Manager/src/test/java/io/raspberrywallet/manager/modules/authorizationserver/AuthServerSecuredTests.java
+++ b/Manager/src/test/java/io/raspberrywallet/manager/modules/authorizationserver/AuthServerSecuredTests.java
@@ -1,6 +1,7 @@
 package io.raspberrywallet.manager.modules.authorizationserver;
 
 
+import io.raspberrywallet.contract.RequiredInputNotFound;
 import io.raspberrywallet.manager.cryptography.crypto.exceptions.DecryptionException;
 import io.raspberrywallet.manager.cryptography.crypto.exceptions.EncryptionException;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,9 +28,7 @@ class AuthServerSecuredTests {
     }
     
     @Test
-    public void Secured_WalletEncryptionAndDecryptionWorks() throws EncryptionException, DecryptionException {
-        assertTrue(module.check());
-    
+    public void Secured_WalletEncryptionAndDecryptionWorks() throws EncryptionException, DecryptionException, RequiredInputNotFound {
         byte[] data = module.encrypt(encryptionData);
         byte[] decryptedData = module.decrypt(data);
     
@@ -37,9 +36,7 @@ class AuthServerSecuredTests {
     }
     
     @Test
-    void Secured_MultipleEncryptionAndDecryptionOperationWorks() throws EncryptionException, DecryptionException {
-        assertTrue(module.check());
-        
+    void Secured_MultipleEncryptionAndDecryptionOperationWorks() throws EncryptionException, DecryptionException, RequiredInputNotFound {
         byte[] firstEncryptedData = module.encrypt(encryptionData);
         assertTrue(Arrays.equals(encryptionData, module.decrypt(firstEncryptedData)));
         

--- a/Manager/src/test/java/io/raspberrywallet/manager/modules/authorizationserver/AuthServerSecuredTests.java
+++ b/Manager/src/test/java/io/raspberrywallet/manager/modules/authorizationserver/AuthServerSecuredTests.java
@@ -1,6 +1,7 @@
 package io.raspberrywallet.manager.modules.authorizationserver;
 
 
+import io.raspberrywallet.contract.InternalModuleException;
 import io.raspberrywallet.contract.RequiredInputNotFound;
 import io.raspberrywallet.manager.cryptography.crypto.exceptions.DecryptionException;
 import io.raspberrywallet.manager.cryptography.crypto.exceptions.EncryptionException;
@@ -28,20 +29,20 @@ class AuthServerSecuredTests {
     }
     
     @Test
-    public void Secured_WalletEncryptionAndDecryptionWorks() throws EncryptionException, DecryptionException, RequiredInputNotFound {
-        byte[] data = module.encrypt(encryptionData);
-        byte[] decryptedData = module.decrypt(data);
+    public void Secured_WalletEncryptionAndDecryptionWorks() throws EncryptionException, DecryptionException, InternalModuleException, RequiredInputNotFound {
+        byte[] data = module.encryptKeyPart(encryptionData);
+        byte[] decryptedData = module.decryptKeyPart(data);
     
         assertTrue(Arrays.equals(decryptedData, encryptionData));
     }
     
     @Test
-    void Secured_MultipleEncryptionAndDecryptionOperationWorks() throws EncryptionException, DecryptionException, RequiredInputNotFound {
-        byte[] firstEncryptedData = module.encrypt(encryptionData);
-        assertTrue(Arrays.equals(encryptionData, module.decrypt(firstEncryptedData)));
-        
-        byte[] secondEncryptedData = module.encrypt(differentEncryptionData);
-        assertTrue(Arrays.equals(differentEncryptionData, module.decrypt(secondEncryptedData)));
+    void Secured_MultipleEncryptionAndDecryptionOperationWorks() throws EncryptionException, DecryptionException, RequiredInputNotFound, InternalModuleException {
+        byte[] firstEncryptedData = module.encryptKeyPart(encryptionData);
+        assertTrue(Arrays.equals(encryptionData, module.decryptKeyPart(firstEncryptedData)));
+
+        byte[] secondEncryptedData = module.encryptKeyPart(differentEncryptionData);
+        assertTrue(Arrays.equals(differentEncryptionData, module.decryptKeyPart(secondEncryptedData)));
     }
     
 }

--- a/Manager/src/test/java/io/raspberrywallet/manager/modules/authorizationserver/AuthServerUnsecuredTests.java
+++ b/Manager/src/test/java/io/raspberrywallet/manager/modules/authorizationserver/AuthServerUnsecuredTests.java
@@ -1,5 +1,6 @@
 package io.raspberrywallet.manager.modules.authorizationserver;
 
+import io.raspberrywallet.contract.InternalModuleException;
 import io.raspberrywallet.contract.RequiredInputNotFound;
 import io.raspberrywallet.manager.Configuration;
 import io.raspberrywallet.manager.commons.CustomConfig;
@@ -32,20 +33,20 @@ class AuthServerUnsecuredTests {
     }
     
     @Test
-    void Unsecured_WalletEncryptionAndDecryptionWorks() throws EncryptionException, DecryptionException, RequiredInputNotFound {
-        byte[] data = module.encrypt(encryptionData);
-        byte[] decryptedData = module.decrypt(data);
+    void Unsecured_WalletEncryptionAndDecryptionWorks() throws EncryptionException, DecryptionException, RequiredInputNotFound, InternalModuleException {
+        byte[] data = module.encryptKeyPart(encryptionData);
+        byte[] decryptedData = module.decryptKeyPart(data);
         
         assertTrue(Arrays.equals(decryptedData, encryptionData));
     }
     
     @Test
-    void Unsecured_MultipleEncryptionAndDecryptionOperationWorks() throws EncryptionException, DecryptionException, RequiredInputNotFound {
-        byte[] firstEncryptedData = module.encrypt(encryptionData);
-        assertTrue(Arrays.equals(encryptionData, module.decrypt(firstEncryptedData)));
-        
-        byte[] secondEncryptedData = module.encrypt(differentEncryptionData);
-        assertTrue(Arrays.equals(differentEncryptionData, module.decrypt(secondEncryptedData)));
+    void Unsecured_MultipleEncryptionAndDecryptionOperationWorks() throws EncryptionException, DecryptionException, RequiredInputNotFound, InternalModuleException {
+        byte[] firstEncryptedData = module.encryptKeyPart(encryptionData);
+        assertTrue(Arrays.equals(encryptionData, module.decryptKeyPart(firstEncryptedData)));
+
+        byte[] secondEncryptedData = module.encryptKeyPart(differentEncryptionData);
+        assertTrue(Arrays.equals(differentEncryptionData, module.decryptKeyPart(secondEncryptedData)));
     }
     
 }

--- a/Manager/src/test/java/io/raspberrywallet/manager/modules/authorizationserver/AuthServerUnsecuredTests.java
+++ b/Manager/src/test/java/io/raspberrywallet/manager/modules/authorizationserver/AuthServerUnsecuredTests.java
@@ -1,5 +1,6 @@
 package io.raspberrywallet.manager.modules.authorizationserver;
 
+import io.raspberrywallet.contract.RequiredInputNotFound;
 import io.raspberrywallet.manager.Configuration;
 import io.raspberrywallet.manager.commons.CustomConfig;
 import io.raspberrywallet.manager.cryptography.crypto.exceptions.DecryptionException;
@@ -31,9 +32,7 @@ class AuthServerUnsecuredTests {
     }
     
     @Test
-    void Unsecured_WalletEncryptionAndDecryptionWorks() throws EncryptionException, DecryptionException {
-        assertTrue(module.check());
-        
+    void Unsecured_WalletEncryptionAndDecryptionWorks() throws EncryptionException, DecryptionException, RequiredInputNotFound {
         byte[] data = module.encrypt(encryptionData);
         byte[] decryptedData = module.decrypt(data);
         
@@ -41,9 +40,7 @@ class AuthServerUnsecuredTests {
     }
     
     @Test
-    void Unsecured_MultipleEncryptionAndDecryptionOperationWorks() throws EncryptionException, DecryptionException {
-        assertTrue(module.check());
-        
+    void Unsecured_MultipleEncryptionAndDecryptionOperationWorks() throws EncryptionException, DecryptionException, RequiredInputNotFound {
         byte[] firstEncryptedData = module.encrypt(encryptionData);
         assertTrue(Arrays.equals(encryptionData, module.decrypt(firstEncryptedData)));
         

--- a/Manager/src/test/java/io/raspberrywallet/manager/modules/pin/PinModuleTests.java
+++ b/Manager/src/test/java/io/raspberrywallet/manager/modules/pin/PinModuleTests.java
@@ -1,5 +1,6 @@
 package io.raspberrywallet.manager.modules.pin;
 
+import io.raspberrywallet.contract.InternalModuleException;
 import io.raspberrywallet.contract.ModuleInitializationException;
 import io.raspberrywallet.contract.RequiredInputNotFound;
 import io.raspberrywallet.manager.cryptography.crypto.exceptions.DecryptionException;
@@ -31,23 +32,23 @@ class PinModuleTests {
 
     
     @Test
-    public void PinModuleEncryptsAndDecryptsCorrectly() throws EncryptionException, RequiredInputNotFound, DecryptionException {
+    public void PinModuleEncryptsAndDecryptsCorrectly() throws EncryptionException, RequiredInputNotFound, DecryptionException, InternalModuleException {
         pinModule.setInput("pin", "1234");
 
-        byte[] encryptedData = pinModule.encrypt(data.getBytes());
-        byte[] decryptedData = pinModule.decrypt(encryptedData);
+        byte[] encryptedData = pinModule.encryptKeyPart(data.getBytes());
+        byte[] decryptedData = pinModule.decryptKeyPart(encryptedData);
         
         assertTrue(Arrays.equals(data.getBytes(), decryptedData));
     }
     
     @Test
-    public void DecryptionDoesThrowWithWrongPin() throws EncryptionException, RequiredInputNotFound {
+    public void DecryptionDoesThrowWithWrongPin() throws EncryptionException, RequiredInputNotFound, InternalModuleException {
         pinModule.setInput("pin", "1234");
 
-        byte[] encryptedData = pinModule.encrypt(data.getBytes());
+        byte[] encryptedData = pinModule.encryptKeyPart(data.getBytes());
         pinModule.clearInputs();
         pinModule.setInput("pin","4567");
-        assertThrows(DecryptionException.class, () -> pinModule.decrypt(encryptedData));
+        assertThrows(DecryptionException.class, () -> pinModule.decryptKeyPart(encryptedData));
     }
     
 }

--- a/Manager/src/test/java/io/raspberrywallet/manager/modules/pin/PinModuleTests.java
+++ b/Manager/src/test/java/io/raspberrywallet/manager/modules/pin/PinModuleTests.java
@@ -4,7 +4,6 @@ import io.raspberrywallet.contract.RequiredInputNotFound;
 import io.raspberrywallet.manager.cryptography.crypto.exceptions.DecryptionException;
 import io.raspberrywallet.manager.cryptography.crypto.exceptions.EncryptionException;
 import io.raspberrywallet.manager.modules.Module;
-import org.apache.commons.lang.SerializationException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -28,19 +27,14 @@ class PinModuleTests {
     public void PinModuleConstructorDoesNotThrow() throws IllegalAccessException, InstantiationException {
         Module<PinConfig> pinModule = new PinModule();
     }
-    
-    @Test
-    public void PinModuleCorrectStateValidationCheckWorks() {
-        pinModule.setInput("pin", "1234");
-        assertTrue(pinModule.check());
-    }
+
     
     @Test
     public void PinModuleEncryptsAndDecryptsCorrectly() throws EncryptionException, RequiredInputNotFound, DecryptionException {
         pinModule.setInput("pin", "1234");
-        
-        byte[] encryptedData = pinModule.encrypt(data.getBytes());
-        byte[] decryptedData = pinModule.decrypt(encryptedData);
+
+        byte[] encryptedData = pinModule.validateAndEncrypt(data.getBytes());
+        byte[] decryptedData = pinModule.validateAndDecrypt(encryptedData);
         
         assertTrue(Arrays.equals(data.getBytes(), decryptedData));
     }
@@ -48,11 +42,11 @@ class PinModuleTests {
     @Test
     public void DecryptionDoesThrowWithWrongPin() throws EncryptionException, RequiredInputNotFound {
         pinModule.setInput("pin", "1234");
-    
-        byte[] encryptedData = pinModule.encrypt(data.getBytes());
+
+        byte[] encryptedData = pinModule.validateAndEncrypt(data.getBytes());
         pinModule.clearInputs();
         pinModule.setInput("pin","4567");
-        assertThrows(DecryptionException.class, () -> pinModule.decrypt(encryptedData));
+        assertThrows(DecryptionException.class, () -> pinModule.validateAndDecrypt(encryptedData));
     }
     
 }

--- a/Manager/src/test/java/io/raspberrywallet/manager/modules/pin/PinModuleTests.java
+++ b/Manager/src/test/java/io/raspberrywallet/manager/modules/pin/PinModuleTests.java
@@ -1,5 +1,6 @@
 package io.raspberrywallet.manager.modules.pin;
 
+import io.raspberrywallet.contract.ModuleInitializationException;
 import io.raspberrywallet.contract.RequiredInputNotFound;
 import io.raspberrywallet.manager.cryptography.crypto.exceptions.DecryptionException;
 import io.raspberrywallet.manager.cryptography.crypto.exceptions.EncryptionException;
@@ -19,12 +20,12 @@ class PinModuleTests {
     private Module<PinConfig> pinModule;
     
     @BeforeEach
-    public void initializeModule() throws IllegalAccessException, InstantiationException {
+    public void initializeModule() throws IllegalAccessException, InstantiationException, ModuleInitializationException {
         pinModule = new PinModule();
     }
     
     @Test
-    public void PinModuleConstructorDoesNotThrow() throws IllegalAccessException, InstantiationException {
+    public void PinModuleConstructorDoesNotThrow() throws IllegalAccessException, InstantiationException, ModuleInitializationException {
         Module<PinConfig> pinModule = new PinModule();
     }
 
@@ -33,8 +34,8 @@ class PinModuleTests {
     public void PinModuleEncryptsAndDecryptsCorrectly() throws EncryptionException, RequiredInputNotFound, DecryptionException {
         pinModule.setInput("pin", "1234");
 
-        byte[] encryptedData = pinModule.validateAndEncrypt(data.getBytes());
-        byte[] decryptedData = pinModule.validateAndDecrypt(encryptedData);
+        byte[] encryptedData = pinModule.encrypt(data.getBytes());
+        byte[] decryptedData = pinModule.decrypt(encryptedData);
         
         assertTrue(Arrays.equals(data.getBytes(), decryptedData));
     }
@@ -43,10 +44,10 @@ class PinModuleTests {
     public void DecryptionDoesThrowWithWrongPin() throws EncryptionException, RequiredInputNotFound {
         pinModule.setInput("pin", "1234");
 
-        byte[] encryptedData = pinModule.validateAndEncrypt(data.getBytes());
+        byte[] encryptedData = pinModule.encrypt(data.getBytes());
         pinModule.clearInputs();
         pinModule.setInput("pin","4567");
-        assertThrows(DecryptionException.class, () -> pinModule.validateAndDecrypt(encryptedData));
+        assertThrows(DecryptionException.class, () -> pinModule.decrypt(encryptedData));
     }
     
 }

--- a/ServerHttp/src/main/java/io/raspberrywallet/contract/InternalModuleException.java
+++ b/ServerHttp/src/main/java/io/raspberrywallet/contract/InternalModuleException.java
@@ -1,0 +1,7 @@
+package io.raspberrywallet.contract;
+
+public class InternalModuleException extends Throwable {
+    public InternalModuleException(String message) {
+        super(message);
+    }
+}

--- a/ServerHttp/src/main/java/io/raspberrywallet/contract/ModuleInitializationException.java
+++ b/ServerHttp/src/main/java/io/raspberrywallet/contract/ModuleInitializationException.java
@@ -1,0 +1,9 @@
+package io.raspberrywallet.contract;
+
+public class ModuleInitializationException extends Throwable {
+    
+    public ModuleInitializationException(String message) {
+        super(message);
+    }
+    
+}

--- a/ServerHttp/src/main/java/io/raspberrywallet/contract/RequiredInputNotFound.java
+++ b/ServerHttp/src/main/java/io/raspberrywallet/contract/RequiredInputNotFound.java
@@ -1,7 +1,13 @@
 package io.raspberrywallet.contract;
 
 public class RequiredInputNotFound extends Throwable {
+    
     public RequiredInputNotFound(String moduleName, String inputName) {
         super("Could not find input: " + inputName + " for module: " + moduleName);
     }
+    
+    public RequiredInputNotFound(String msg) {
+        super(msg);
+    }
+    
 }

--- a/ServerHttp/src/main/java/io/raspberrywallet/contract/ServerConfig.java
+++ b/ServerHttp/src/main/java/io/raspberrywallet/contract/ServerConfig.java
@@ -16,4 +16,7 @@ public class ServerConfig {
     public char[] keystorePassword = "raspberrywallet".toCharArray();
     @JsonProperty("key-alias")
     public String keyAlias = "ssl";
+    public int port = 80;
+    @JsonProperty("secure-port")
+    public int securePort = 433;
 }

--- a/ServerHttp/src/main/kotlin/io/raspberrywallet/server/KtorServer.kt
+++ b/ServerHttp/src/main/kotlin/io/raspberrywallet/server/KtorServer.kt
@@ -57,9 +57,6 @@ import java.io.FileInputStream
 import java.security.KeyStore
 import java.time.Duration
 
-
-const val PORT = 9090
-const val PORT_SSL = 443
 lateinit var globalManager: Manager
 
 class KtorServer(val manager: Manager,
@@ -81,10 +78,10 @@ class KtorServer(val manager: Manager,
                 mainModule()
             }
             connector {
-                port = PORT
+                port = serverConfig.port
             }
             sslConnector(keyStore, "ssl", { serverConfig.keystorePassword }, { serverConfig.keystorePassword }) {
-                port = PORT_SSL
+                port = serverConfig.securePort
                 keyStorePath = keyStoreFile.absoluteFile
             }
         }

--- a/config.yaml
+++ b/config.yaml
@@ -10,6 +10,8 @@ server:
   keystore-name: RaspberryWallet.keystore
   keystore-password: raspberrywallet
   key-alias: ssl
+  port: 80
+  secure-port: 433
 
 modules:
   PinModule:

--- a/config.yaml
+++ b/config.yaml
@@ -18,7 +18,7 @@ modules:
   AuthorizationServerModule:
     host: https://127.0.0.1
     port: 8443
-    accept-unstrusted-certs: true
+    accept-untrusted-certs: true
     endpoints:
       set-secret: /authorization/secret/set
       overwrite: /authorization/secret/overwritte


### PR DESCRIPTION
replace `check()` with `validateInput()` which must throw `RequiredInputNotFound` if the input is not present or incorrect.
add public wrapper methods `validateAndEncrypt()` which will force framework to `validateInputs()` before en/decryption
modules override protected methods decrypt/encrypt
implemented changes in `PinModule`, `ButtonModule` and `ExampleModule`

@PatrykMilewski please approve this concept and implement those changes in `AuthorizationServerModule`

Closes #87 

server port as config property
default port 80
default secure-port: 433

Took 1 hour 59 minutes